### PR TITLE
Peer in long-polling example changed to username

### DIFF
--- a/docs/docs/UPDATES.md
+++ b/docs/docs/UPDATES.md
@@ -248,7 +248,7 @@ while (true) {
                 }
 
                 try {
-                    $MadelineProto->messages->sendMessage(['peer' => $update, 'message' => $res, 'reply_to_msg_id' => $update['update']['message']['id'], 'entities' => [['_' => 'messageEntityPre', 'offset' => 0, 'length' => strlen($res), 'language' => 'json']]]);
+                    $MadelineProto->messages->sendMessage(['peer' => '@danogentili', 'message' => $res, 'reply_to_msg_id' => $update['update']['message']['id'], 'entities' => [['_' => 'messageEntityPre', 'offset' => 0, 'length' => strlen($res), 'language' => 'json']]]);
                 } catch (\danog\MadelineProto\RPCErrorException $e) {
                     $MadelineProto->messages->sendMessage(['peer' => '@danogentili', 'message' => $e->getCode().': '.$e->getMessage().PHP_EOL.$e->getTraceAsString()]);
                 }


### PR DESCRIPTION
Peer was `$update`. Probably a typo. It caused run-time errors. Changed to a Telegram username (@danogentili).