### PR TITLE
Updating invalid logger file's 'max_size' default value

### DIFF
--- a/docs/docs/SETTINGS.md
+++ b/docs/docs/SETTINGS.md
@@ -294,7 +294,7 @@ Description: You can provide a token for the rollbar log management system
 
 
 ### `$settings['logger']['max_size']`
-Default: `100*1024*1024`
+Default: `1*1024*1024`
 Description: Maximum file size of logfiles for logging to files. When the logfile reaches the provided size, it gets deleted automatically.
 
 

--- a/docs/docs/SETTINGS.md
+++ b/docs/docs/SETTINGS.md
@@ -295,7 +295,7 @@ Description: You can provide a token for the rollbar log management system
 
 ### `$settings['logger']['max_size']`
 Default: `1*1024*1024`
-Description: Maximum file size of logfiles for logging to files. When the logfile reaches the provided size, it gets deleted automatically.
+Description: Maximum file size of logfiles for logging to files in bytes. When the logfile reaches the provided size, it gets deleted automatically.
 
 
 <hr>


### PR DESCRIPTION
[Reference code](https://github.com/danog/MadelineProto/blob/2bac25d8cb4867eaac0beebfca6f52de83b5437f/src/danog/MadelineProto/Settings/Logger.php#L79)