### PR TITLE
Fix spelling mistake

### DIFF
--- a/docs/API_docs/methods/account.initTakeoutSession.md
+++ b/docs/API_docs/methods/account.initTakeoutSession.md
@@ -1,6 +1,6 @@
 ---
 title: account.initTakeoutSession
-description: Intialize account takeout session
+description: Initialize account takeout session
 image: https://docs.madelineproto.xyz/favicons/android-chrome-256x256.png
 redirect_from: /API_docs/methods/account_initTakeoutSession.html
 ---
@@ -9,7 +9,7 @@ redirect_from: /API_docs/methods/account_initTakeoutSession.html
 
 
 
-Intialize account takeout session
+Initialize account takeout session
 
 ### Parameters:
 


### PR DESCRIPTION
Fixed a small spelling mistake:
~~Intialize~~ → Initialize

[(Fixed the same issue in the README of danog/MadelineProto which is linking here too)](https://github.com/danog/MadelineProto/pull/1036)